### PR TITLE
Fixed PowerPlant logic for encounters

### DIFF
--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -637,7 +637,7 @@
         },
         {
           "name": "Power Plant",
-          "access_rules": ["$cerulean,$cut,$surf,plantkey","$lavender,^$rock_tunnel,$surf"],
+          "access_rules": ["^$powerplant"],
           "sections": [
                     {
                         "name": "Pokémon 1:1",


### PR DESCRIPTION
Fixed the logic for Power Plant encounters. Uses the `logic.lua` function

Have tested this myself, and it is fixed