### PR TITLE
Revert "Fixes Backwards-Accessibility of Route 23"

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -3260,24 +3260,24 @@
         },	
         {	
           "name": "Route 23",	
-          "access_rules": [],	
+          "access_rules": ["^$rt23,^$surf"],	
           "sections": [	
             {	
               "name": "HI: On Island",	
               "item_count": 1,	
-              "access_rules": ["^$hidden,^$rt23,^$surf","^$hidden,$indigo,$surf,$strength,$victoryroad"],	
+              "access_rules": ["^$hidden"],	
               "visibility_rules": ["opt_hidden_items_on"]	
             },	
             {	
               "name": "HI: East Bush After Water",	
               "item_count": 1,	
-              "access_rules": ["^$hidden,^$rt23,^$surf","^$hidden,$indigo,$strength,$victoryroad"],	
+              "access_rules": ["^$hidden"],	
               "visibility_rules": ["opt_hidden_items_on"]	
             },	
             {	
               "name": "HI: Rocks Before Victory Road",	
               "item_count": 1,	
-              "access_rules": ["^$hidden,^$rt23,^$surf","^$hidden,$indigo,$strength,$victoryroad"],	
+              "access_rules": ["^$hidden"],	
               "visibility_rules": ["opt_hidden_items_on"]	
             }	
 	


### PR DESCRIPTION
Reverts coveleski/rb_tracker#52 because this may be functional but it is an messy and inefficient way to handle these access rules.