### PR TITLE
actually removing tea from Key items

### DIFF
--- a/items/items.json
+++ b/items/items.json
@@ -626,7 +626,7 @@
             },
             {
                 "name": "Tea",
-                "codes": "tea,keyitem",
+                "codes": "tea",
                 "img": "images/items/tea.png"
             }
         ]


### PR DESCRIPTION
Noticed Cerulean Cave was still in logic in one of my seeds. keyitem was still in one of the stages of Tea. The previous patch only removed it from one of the other ones.