### PR TITLE
Encounter Tab Overhaul

### DIFF
--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -158,7 +158,7 @@
                 ]
             },
             {
-                "name": "Route 2", ## Route 2 in locations.json has $cut as a requirement since all items are cut-locked. So, here we use custom access rules.
+                "name": "Route 2", // Route 2 in locations.json has $cut as a requirement since all items are cut-locked. So, here we use custom access rules.
                 "access_rules": [
                     "^$pewter",
                     "$cut",
@@ -185,7 +185,7 @@
                         "name": "Trade",
                         "access_rules": [
                             "$cut",
-                            "@Kanto/Vermilion City" # Trade is possible without cut if you come from Vermillion
+                            "@Kanto/Vermilion City" // Trade is possible without cut if you come from Vermillion
                         ]
                     }
                 ],
@@ -639,7 +639,7 @@
             {
                 "name": "Route 4",
                 "access_rules": [
-                    "@Kanto/Cerulean City" # Route 4 has more requirements in locations.json. Route 4-Mons can be accessed if you have access to cerulean.
+                    "@Kanto/Cerulean City" // Route 4 has more requirements in locations.json. Route 4-Mons can be accessed if you have access to cerulean.
                 ],
                 "sections": [
                     {
@@ -1760,7 +1760,7 @@
             {
                 "name": "Route 12",
                 "access_rules": [
-                    "@Kanto/Lavender Town, pokeflute" # If you have access to Snorlax from the west or south and have a flute, you also have access to lavender
+                    "@Kanto/Lavender Town, pokeflute" // If you have access to Snorlax from the west or south and have a flute, you also have access to lavender
                 ],
                 "sections": [
                     {

--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -1,73 +1,123 @@
 [
     {
-      "name": "Encounters",
-      "chest_unopened_img": "images/items/pokedex.png",
-      "chest_opened_img": "images/items/pokedex_done.png",
-      "children": [
-        {
-          "name": "Vermilion City",
-          "access_rules": ["$cerulean"],
-          "sections": [
-					{
-						"name": "Trade",
-						"access_rules": []
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 400, "y": 304, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Fuchsia City",
-          "access_rules": ["$fuchsia"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 336, "y": 432, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Route 12 South",
-          "access_rules": ["$fuchsia,$extra_boulders","$lavender,$surf","$cerulean,flute"],
-          "sections": [
+        "name": "Encounters",
+        "chest_unopened_img": "images/items/pokedex.png",
+        "chest_opened_img": "images/items/pokedex_done.png",
+        "children": [
+            {
+                "name": "Vermilion City",
+                "access_rules": [
+                    "@Kanto/Vermilion City"
+                ],
+                "sections": [
+                    {
+                        "name": "Trade",
+                        "access_rules": []
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 400,
+                        "y": 304,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Fuchsia City",
+                "access_rules": [
+                    "@Kanto/Fuchsia City"
+                ],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 336,
+                        "y": 432,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Route 12 South",
+                "access_rules": [
+                    "@Kanto/Route 12 South"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 3,
-			"access_rules": ["$cut"],
+                        "access_rules": [
+                            "$cut"
+                        ],
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
-			"access_rules": ["$cut"],
+                        "access_rules": [
+                            "$cut"
+                        ],
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 528, "y": 336 }]
-        },
-        {
-          "name": "Pallet Town",
-          "access_rules": [],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 144, "y": 368, "size": 27, "border_thickness": 4}]
-        },
-        {
-          "name": "Celadon City",
-          "access_rules": ["$celadon"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 528,
+                        "y": 336
+                    }
+                ]
+            },
             {
-                "name": "Static Encounter: Eevee",
-                "chest_unopened_img": "images/pokedex/eevee.png",
-                "access_rules": []
-            }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 304, "y": 176, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Route 1",
-          "access_rules": [],
-          "sections": [
+                "name": "Pallet Town",
+                "access_rules": [],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 144,
+                        "y": 368,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Celadon City",
+                "access_rules": [
+                    "@Kanto/Celadon City"
+                ],
+                "sections": [
+                    {
+                        "name": "Static Encounter: Eevee",
+                        "chest_unopened_img": "images/pokedex/eevee.png",
+                        "access_rules": []
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 304,
+                        "y": 176,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Route 1",
+                "access_rules": [],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 2,
@@ -84,57 +134,90 @@
                             "opt_encounter_ten"
                         ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 144, "y": 320 }]
-        },
-        {
-          "name": "Viridian City",
-          "access_rules": [],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 144, "y": 272,"size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Route 2",
-		  "access_rules": ["$pewter", "$cut", "$old_man"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 144,
+                        "y": 320
+                    }
+                ]
+            },
+            {
+                "name": "Viridian City",
+                "access_rules": [],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 144,
+                        "y": 272,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Route 2",
+                "access_rules": [
+                    "^$pewter",
+                    "$cut",
+                    "$old_man"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 3,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
-					{
-						"name": "Trade",
-						"access_rules": ["$cut","$vermilion"]
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 144, "y": 208 }]
-        },
+                    {
+                        "name": "Trade",
+                        "access_rules": [
+                            "$cut",
+                            "^$vermilion"
+                        ]
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 144,
+                        "y": 208
+                    }
+                ]
+            },
             {
                 "name": "Diglett's Cave",
                 "access_rules": [
-                    "$cut","$vermilion"
+                    "$cut",
+                    "^$vermilion"
                 ],
                 "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 2,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     }
                 ],
@@ -146,435 +229,661 @@
                     }
                 ]
             },
-        {
-          "name": "Pewter City",
-          "access_rules": ["$pewter"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 144, "y": 112, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Cerulean City",
-          "access_rules": ["$cerulean"],
-          "sections": [
-					{
-						"name": "Trade",
-						"access_rules": []
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 400, "y": 80, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Route 24",
-          "access_rules": ["$cerulean"],
-          "sections": [
+            {
+                "name": "Pewter City",
+                "access_rules": [
+                    "@Kanto/Pewter City"
+                ],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 144,
+                        "y": 112,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Cerulean City",
+                "access_rules": [
+                    "@Kanto/Cerulean City"
+                ],
+                "sections": [
+                    {
+                        "name": "Trade",
+                        "access_rules": []
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 400,
+                        "y": 80,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Route 24",
+                "access_rules": [
+                    "@Kanto/Route 24"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 5,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 400, "y": 48 }]
-        },
-        {
-          "name": "Route 25",
-          "access_rules": ["$cerulean"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 400,
+                        "y": 48
+                    }
+                ]
+            },
+            {
+                "name": "Route 25",
+                "access_rules": [
+                    "@Kanto/Route 25"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 7,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 448, "y": 16 }]
-        },
-        {
-          "name": "Lavender Town",
-          "access_rules": ["$lavender"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 528, "y": 176, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Route 12 North",
-          "access_rules": ["$lavender","$cerulean,$extra_boulders,pokeflute","$fuchsia,$extra_boulders,pokeflute"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 528, "y": 272 }]
-        },
-        {
-          "name": "Route 11-12 Gatehouse",
-          "access_rules": ["$cerulean,$extra_boulders","$lavender,pokeflute"],
-          "sections": [
-					{
-						"name": "Trade",
-						"access_rules": []
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 496, "y": 304 }]
-        },
-        {
-          "name": "Silph Co 1F - 6F",
-          "access_rules": ["$saffron,fuji"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 368, "y": 144 }]
-        },
-        {
-          "name": "Silph Co 7F - 11F",
-          "access_rules": ["$saffron,fuji"],
-          "sections": [
-					{
-						"name": "Static Encounter: Lapras",
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 448,
+                        "y": 16
+                    }
+                ]
+            },
+            {
+                "name": "Lavender Town",
+                "access_rules": [
+                    "$lavender"
+                ],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 528,
+                        "y": 176,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Route 12 North",
+                "access_rules": [
+                    "@Kanto/Route 12 North"
+                ],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 528,
+                        "y": 272
+                    }
+                ]
+            },
+            {
+                "name": "Route 11-12 Gatehouse",
+                "access_rules": [
+                    "^$vermilion,^$extra_boulders","^$lavender,pokeflute"
+                ],
+                "sections": [
+                    {
+                        "name": "Trade",
+                        "access_rules": []
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 496,
+                        "y": 304
+                    }
+                ]
+            },
+            {
+                "name": "Silph Co 1F - 6F",
+                "access_rules": [
+                    "$saffron,fuji"
+                ],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 368,
+                        "y": 144
+                    }
+                ]
+            },
+            {
+                "name": "Silph Co 7F - 11F",
+                "access_rules": [
+                    "@Kanto/Silph Co 7F - 11F/11F Rocket 2"
+					// This is specifically 11F Rocket 2 to ensure they have access to this warp
+                ],
+                "sections": [
+                    {
+                        "name": "Static Encounter: Lapras",
                         "chest_unopened_img": "images/pokedex/lapras.png",
-						"access_rules": []
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 340, "y": 144 }]
-        },
-        {
-          "name": "Route 16",
-          "access_rules": [],
-          "sections": [
+                        "access_rules": []
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 340,
+                        "y": 144
+                    }
+                ]
+            },
+            {
+                "name": "Route 16",
+                "access_rules": [],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"],
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ],
                         "access_rules": [
-                            "$celadon,$cut"
+                            "@Kanto/Route 16/Fly House Woman"
                         ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "$celadon,$cut"
+                            "@Kanto/Route 16/Fly House Woman"
                         ]
                     },
-					{
-						"name": "Static Encounter: Snorlax",
-						"access_rules": ["pokeflute,$celadon","pokeflute,$fuchsia,$cyclingroad"],
+                    {
+                        "name": "Static Encounter: Snorlax",
+                        "access_rules": [
+                            "pokeflute,^$celadon",
+                            "pokeflute,^$fuchsia,^$cyclingroad"
+                        ],
                         "chest_unopened_img": "images/pokedex/snorlax.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 240, "y": 176 }]
-        },
-        {
-          "name": "Route 15",
-          "access_rules": ["$fuchsia"],
-          "sections": [
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 240,
+                        "y": 176
+                    }
+                ]
+            },
+            {
+                "name": "Route 15",
+                "access_rules": [
+                    "@Kanto/Route 15"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 6,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 400, "y": 432 }]
-        },
-        {
-          "name": "Safari Zone",
-          "access_rules": ["$fuchsia,safaripass"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 400,
+                        "y": 432
+                    }
+                ]
+            },
+            {
+                "name": "Safari Zone",
+                "access_rules": [
+                    "@Kanto/Safari Zone"
+                ],
+                "sections": [
                     {
                         "name": "Center Zone Pokémon 1:1",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Center Zone Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "East Zone Pokémon 1:1",
                         "item_count": 9,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "East Zone Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "North Zone Pokémon 1:1",
                         "item_count": 9,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "North Zone Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "West Zone Pokémon 1:1",
                         "item_count": 9,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "West Zone Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 336, "y": 400 }]
-        },
-        {
-          "name": "Cinnabar Island",
-          "access_rules": ["$cinnabar"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 336,
+                        "y": 400
+                    }
+                ]
+            },
+            {
+                "name": "Cinnabar Island",
+                "access_rules": [
+                    "@Kanto/Cinnabar Island"
+                ],
+                "sections": [
+                    {
+                        "name": "Trade",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "access_rules": []
+                    },
 					{
-						"name": "Trade",
-						"item_count": 3,
+						"name": "Fossil: Old Amber",
+						"item_count": 1,
 						"clear_as_group": false,
-						"access_rules": []
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 144, "y": 496, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Saffron City",
-          "access_rules": ["$saffron"],
-          "sections": [
-					{
-						"name": "Static Encounter: Hitmonlee",
-                        "chest_unopened_img": "images/pokedex/hitmonlee.png",
-						"access_rules": []
+						"access_rules": ["oldamber"],
+                        "chest_unopened_img": "images/items/oldamber.png",
 					},
 					{
-						"name": "Static Encounter: Hitmonchan",
-                        "chest_unopened_img": "images/pokedex/hitmonchan.png",
-						"access_rules": []
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 400, "y": 176, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Fossil",
-          "access_rules": ["$pewter,$rt3","$cerulean,$surf"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 272, "y": 48 }]
-        },
-        {
-          "name": "Route 4",
-          "access_rules": ["$pewter,$rt3"],
-          "sections": [
-                    {
-                        "name": "Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
-                    },
+						"name": "Fossil: Dome Fossil",
+						"item_count": 1,
+						"clear_as_group": false,
+						"access_rules": ["domefossil"],
+                        "chest_unopened_img": "images/items/dome.png",
+					},
 					{
-						"name": "Purchase Magikarp",
-						"access_rules": []
+						"name": "Fossil: Helix Fossil",
+						"item_count": 1,
+						"clear_as_group": false,
+						"access_rules": ["helixfossil"],
+                        "chest_unopened_img": "images/items/helix.png",
 					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 336, "y": 80 }]
-        },
-        {
-          "name": "Route 9",
-          "access_rules": ["$cerulean,$cut","$lavender,^$rock_tunnel"],
-          "sections": [
+                ],
+                "map_locations": [
                     {
-                        "name": "Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
-                        ]
+                        "map": "encounters",
+                        "x": 144,
+                        "y": 496,
+                        "size": 27,
+                        "border_thickness": 4
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 464, "y": 80 }]
-        },
-        {
-          "name": "Cerulean Cave",
-          "access_rules": ["$cerulean,$ceruleancave,$surf"],
-          "sections": [
-                    {
-                        "name": "1F Pokémon 1:1",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "1F Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
-                    },
-                    {
-                        "name": "2F Pokémon 1:1",
-                        "item_count": 9,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "2F Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
-                    },
-                    {
-                        "name": "B2F Pokémon 1:1",
-                        "item_count": 8,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "B2F Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
-                    },
-					{
-						"name": "Static Encounter: Mewtwo",
-						"access_rules": [],
-                        "chest_unopened_img": "images/pokedex/mewtwo.png",
-                        "chest_opened_img": "images/items/pokedex_done.png"
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 368, "y": 48 }]
-        },
-        {
-          "name": "Pokemon Tower",
-          "access_rules": ["silphscope,$lavender"],
-          "sections": [
-                    {
-                        "name": "3F Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "3F Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
-                    },
-                    {
-                        "name": "4F Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "4F Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
-                        ]
-                    },
-                    {
-                        "name": "5F Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "5F Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
-                        ]
-                    },
-                    {
-                        "name": "6F Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "6F Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
-                        ]
-                    },
-                    {
-                        "name": "7F Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "7F Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
-                        ]
-                    }
-		],
-          "map_locations": [{ "map": "encounters", "x": 560, "y": 176 }]
-        },
+                ]
+            },
             {
-                "name": "Route 5",
+                "name": "Saffron City",
                 "access_rules": [
-                    "$vermilion"
+                    "@Kanto/Saffron City"
+                ],
+                "sections": [
+                    {
+                        "name": "Static Encounter: Hitmonlee",
+                        "chest_unopened_img": "images/pokedex/hitmonlee.png",
+                        "access_rules": []
+                    },
+                    {
+                        "name": "Static Encounter: Hitmonchan",
+                        "chest_unopened_img": "images/pokedex/hitmonchan.png",
+                        "access_rules": []
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 400,
+                        "y": 176,
+                        "size": 27,
+                        "border_thickness": 4
+                    }
+                ]
+            },
+            {
+                "name": "Route 4",
+                "access_rules": [
+                    "^$cerulean"
                 ],
                 "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 3,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 336,
+                        "y": 80
+                    }
+                ]
+            },
+            {
+                "name": "Route 9",
+                "access_rules": [
+                    "@Kanto/Route 9"
+                ],
+                "sections": [
+                    {
+                        "name": "Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 464,
+                        "y": 80
+                    }
+                ]
+            },
+            {
+                "name": "Cerulean Cave",
+                "access_rules": [
+                    "@Kanto/Cerulean Cave"
+                ],
+                "sections": [
+                    {
+                        "name": "1F Pokémon 1:1",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "1F Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    },
+                    {
+                        "name": "2F Pokémon 1:1",
+                        "item_count": 9,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "2F Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    },
+                    {
+                        "name": "B2F Pokémon 1:1",
+                        "item_count": 8,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "B2F Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    },
+                    {
+                        "name": "Static Encounter: Mewtwo",
+                        "access_rules": [],
+                        "chest_unopened_img": "images/pokedex/mewtwo.png",
+                        "chest_opened_img": "images/items/pokedex_done.png"
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 368,
+                        "y": 48
+                    }
+                ]
+            },
+            {
+                "name": "Pokemon Tower",
+                "access_rules": [
+                    "@Kanto/Pokemon Tower, silphscope"
+                ],
+                "sections": [
+                    {
+                        "name": "3F Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "3F Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    },
+                    {
+                        "name": "4F Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "4F Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    },
+                    {
+                        "name": "5F Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "5F Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    },
+                    {
+                        "name": "6F Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "6F Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    },
+                    {
+                        "name": "7F Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "7F Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 560,
+                        "y": 176
+                    }
+                ]
+            },
+            {
+                "name": "Route 5",
+                "access_rules": [
+                    "@Kanto/Route 6"
+                ],
+                "sections": [
+                    {
+                        "name": "Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
                 ],
                 "map_locations": [
@@ -585,510 +894,749 @@
                     }
                 ]
             },
-        {
-          "name": "Pokemon Mansion",
-          "access_rules": ["$cinnabar,mansionkey", "$cinnabar,opt_extra_key_items_off"],
-          "sections": [
+            {
+                "name": "Pokemon Mansion",
+                "access_rules": [
+                    "@Kanto/Pokemon Mansion"
+                ],
+                "sections": [
                     {
                         "name": "1F Pokémon 1:1",
                         "item_count": 6,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "2F Pokémon 1:1",
                         "item_count": 6,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "2F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "3F Pokémon 1:1",
                         "item_count": 6,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "3F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "B1F Pokémon 1:1",
                         "item_count": 7,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "B1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 112, "y": 496 }]
-        },
-        {
-          "name": "Power Plant",
-          "access_rules": ["^$powerplant"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 112,
+                        "y": 496
+                    }
+                ]
+            },
+            {
+                "name": "Power Plant",
+                "access_rules": [
+                    "@Kanto/Power Plant"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 5,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
-					{
-						"name": "Static Encounter: Balls",
-						"access_rules": [],
-						"item_count": 6,
-						"clear_as_group": false,
-                        "chest_unopened_img": "images/pokedex/voltorb.png",
-                        "chest_opened_img": "images/items/pokedex_done.png"
-					},
-					{
-						"name": "Static Encounter: Zapdos",
-						"access_rules": [],
-                        "chest_unopened_img": "images/pokedex/zapdos.png",
-                        "chest_opened_img": "images/items/pokedex_done.png"
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 560, "y": 80 }]
-        },
-        {
-          "name": "Victory Road",
-          "access_rules": ["$rt23,$surf,$victoryroad,$strength","$flyto|indigo,$strength"],
-          "sections": [
+                    {
+                        "name": "Static Encounter: Balls",
+                        "access_rules": [],
+                        "item_count": 6,
+                        "clear_as_group": false,
+                        "chest_unopened_img": "images/pokedex/voltorb.png"
+                    },
+                    {
+                        "name": "Static Encounter: Zapdos",
+                        "access_rules": [],
+                        "chest_unopened_img": "images/pokedex/zapdos.png"
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 560,
+                        "y": 80
+                    }
+                ]
+            },
+            {
+                "name": "Victory Road",
+                "access_rules": [
+                    "" // This one needs specific access rules because parts of it can be accessed with various combinations backwards but not forwards and vice versa
+                ],
+                "sections": [
                     {
                         "name": "1F Pokémon 1:1",
                         "item_count": 8,
                         "clear_as_group": false,
-                        "visibility_rules": ["dexsanity_one"]
+                "access_rules": [
+                    "^$rt23, ^$victoryroad, $surf", "^$indigo, $strength"
+                ],
+                        "visibility_rules": [
+                            "dexsanity_one"
+                        ]
                     },
                     {
                         "name": "1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                "access_rules": [
+                    "^$rt23, ^$victoryroad, $surf", "^$indigo, $strength"
+                ],
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "2F Pokémon 1:1",
                         "item_count": 9,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                "access_rules": [
+                    "^$indigo" // This is specifically because you can reach a small 3x3 section of 2F by going backwards, with no strength. If you go forwards you have indigo access either way.
+                ],
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "2F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                "access_rules": [
+                    "^$indigo" // This is specifically because you can reach a small 3x3 section of 2F by going backwards, with no strength. If you go forwards you have indigo access either way.
+                ],
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "3F Pokémon 1:1",
                         "item_count": 8,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                "access_rules": [
+                    "^$indigo"
+                ],
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "3F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                "access_rules": [
+                    "^$indigo"
+                ],
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
-					{
-						"name": "Static Encounter: Moltres",
-						"access_rules": [],
+                    {
+                        "name": "Static Encounter: Moltres",
+                        "access_rules": ["^$indigo, $strength"],
                         "chest_unopened_img": "images/pokedex/moltres.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 80, "y": 144 }]
-        },
-        {
-          "name": "Viridian Forest",
-          "access_rules": ["$pewter", "$cut", "$old_man"],
-          "sections": [
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 80,
+                        "y": 144
+                    }
+                ]
+            },
+            {
+                "name": "Viridian Forest",
+                "access_rules": [
+                    "@Kanto/Viridian Forest"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 5,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 144, "y": 144 }]
-        },
-        {
-          "name": "Mt Moon",
-          "access_rules": ["$pewter,$rt3","$cerulean,$surf"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 144,
+                        "y": 144
+                    }
+                ]
+            },
+            {
+                "name": "Mt Moon",
+                "access_rules": [
+                    "@Kanto/Mt Moon"
+                ],
+                "sections": [
                     {
                         "name": "1F Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     },
                     {
                         "name": "B1F Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "B1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     },
                     {
                         "name": "B2F Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "B2F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 272, "y": 80 }]
-        },
-        {
-          "name": "Rocket Hideout",
-          "access_rules": ["$celadon,hideoutkey"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 288, "y": 208 }]
-        },
-        {
-          "name": "Rock Tunnel",
-          "access_rules": ["$lavender,^$rock_tunnel","$cerulean,$cut,^$rock_tunnel"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 272,
+                        "y": 80
+                    }
+                ]
+            },
+            {
+                "name": "Rocket Hideout",
+                "access_rules": [
+                    "@Kanto/Rocket Hideout"
+                ],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 288,
+                        "y": 208
+                    }
+                ]
+            },
+            {
+                "name": "Rock Tunnel",
+                "access_rules": [
+                    "@Kanto/Rock Tunnel"
+                ],
+                "sections": [
                     {
                         "name": "B1F Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "B1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "1F Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 528, "y": 112 }]
-        },
-        {
-          "name": "Route 10 North",
-          "access_rules": ["$lavender,^$rock_tunnel","$cerulean,$cut"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 528,
+                        "y": 112
+                    }
+                ]
+            },
+            {
+                "name": "Route 10 North",
+                "access_rules": [
+                    "@Kanto/Route 10 North"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 3,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 528, "y": 80 }]
-        },
-        {
-          "name": "Route 10 South",
-          "access_rules": ["$lavender","$cerulean,$cut,^$rock_tunnel"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 528, "y": 144 }]
-        },
-        {
-          "name": "Route 13",
-          "access_rules": ["$fuchsia"],
-          "sections": [
-                     {
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 528,
+                        "y": 80
+                    }
+                ]
+            },
+            {
+                "name": "Route 10 South",
+                "access_rules": [
+                    "@Kanto/Route 10 South"
+                ],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 528,
+                        "y": 144
+                    }
+                ]
+            },
+            {
+                "name": "Route 13",
+                "access_rules": [
+                    "@Kanto/Route 13"
+                ],
+                "sections": [
+                    {
                         "name": "Pokémon 1:1",
                         "item_count": 5,
-			"access_rules": ["$cut"],
+                        "access_rules": [
+                            "$cut"
+                        ],
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
-			"access_rules": ["$cut"],
+                        "access_rules": [
+                            "$cut"
+                        ],
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 480, "y": 368 }]
-        },
-        {
-          "name": "Seafoam Islands",
-          "access_rules": ["$cinnabar,$surf","$fuchsia,$surf"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 480,
+                        "y": 368
+                    }
+                ]
+            },
+            {
+                "name": "Seafoam Islands",
+                "access_rules": [
+                    "@Kanto/Seafoam Islands"
+                ],
+                "sections": [
                     {
                         "name": "1F Pokémon 1:1",
                         "item_count": 8,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "B1F Pokémon 1:1",
                         "item_count": 7,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "B1F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "B2F Pokémon 1:1",
                         "item_count": 7,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "B2F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "B3F Pokémon 1:1",
                         "item_count": 6,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "B3F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "B4F Pokémon 1:1",
                         "item_count": 6,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "B4F Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
-					{
-						"name": "Static Encounter: Articuno",
-						"access_rules": ["$strength"],
+                    {
+                        "name": "Static Encounter: Articuno",
+                        "access_rules": [
+                            "$strength"
+                        ],
                         "chest_unopened_img": "images/pokedex/articuno.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 240, "y": 496 }]
-        },
-        {
-          "name": "Route 23",
-          "access_rules": ["$rt23,$surf"],
-          "sections": [
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 240,
+                        "y": 496
+                    }
+                ]
+            },
+            {
+                "name": "Route 23",
+                "access_rules": [
+                    "@Kanto/Route 23"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 5,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 80, "y": 208 }]
-        },
-        {
-          "name": "Route 11",
-          "access_rules": ["$cerulean"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 80,
+                        "y": 208
+                    }
+                ]
+            },
+            {
+                "name": "Route 11",
+                "access_rules": [
+                    "@Kanto/Route 11"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 3,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 448, "y": 304 }]
-        },
-        {
-          "name": "Route 17",
-          "access_rules": ["$cyclingroad,$fuchsia","$cyclingroad,$celadon,pokeflute"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 448,
+                        "y": 304
+                    }
+                ]
+            },
+            {
+                "name": "Route 17",
+                "access_rules": [
+                    "@Kanto/Route 17"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 208, "y": 304 }]
-        },
-        {
-          "name": "Underground Tunnel North-South",
-          "access_rules": ["$cerulean"],
-          "sections": [
-					{
-						"name": "Trade",
-						"access_rules": []
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 400, "y": 144 }]
-        },
-        {
-          "name": "Underground Tunnel West-East",
-          "access_rules": ["$celadon"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 432, "y": 176 }]
-        },
-        {
-          "name": "S.S. Anne",
-          "access_rules": ["$vermilion,ssticket"],
-          "sections": [
-					{
-						"name": "Static Encounter: Mew",
-						"access_rules": ["$surf"],
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 208,
+                        "y": 304
+                    }
+                ]
+            },
+            {
+                "name": "S.S. Anne",
+                "access_rules": [
+                    "@Kanto/S.S. Anne"
+                ],
+                "sections": [
+                    {
+                        "name": "Static Encounter: Mew",
+                        "access_rules": [
+                            "$surf"
+                        ],
                         "chest_unopened_img": "images/pokedex/mew.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 368, "y": 304 }]
-        },
-        {
-          "name": "Route 21",
-          "access_rules": ["$surf"],
-          "sections": [
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 368,
+                        "y": 304
+                    }
+                ]
+            },
+            {
+                "name": "Route 21",
+                "access_rules": [
+                    "@Kanto/Route 21"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon (Grass) 1:1",
                         "item_count": 5,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon (Grass)",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
                     {
                         "name": "Pokémon (Surf) 1:1",
                         "item_count": 1,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon (Surf)",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 144, "y": 432 }]
-        },
-        {
-          "name": "Route 20 West",
-          "access_rules": ["$surf"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 144,
+                        "y": 432
+                    }
+                ]
+            },
+            {
+                "name": "Route 20 West",
+                "access_rules": [
+                    "@Kanto/Route 20 West"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 1,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 192, "y": 496 }]
-        },
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 192,
+                        "y": 496
+                    }
+                ]
+            },
             {
                 "name": "Route 22",
                 "access_rules": [],
@@ -1097,13 +1645,17 @@
                         "name": "Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
                 ],
                 "map_locations": [
@@ -1114,212 +1666,317 @@
                     }
                 ]
             },
-        {
-          "name": "Route 20 East",
-          "access_rules": ["$fuchsia,$surf","$surf,$strength"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 288, "y": 496 }]
-        },
-        {
-          "name": "Route 19",
-          "access_rules": [],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 336, "y": 480 }]
-        },
-        {
-          "name": "Route 18",
-          "access_rules": ["$fuchsia"],
-          "sections": [
-                     {
+            {
+                "name": "Route 20 East",
+                "access_rules": [
+                    "@Kanto/Route 20 East"
+                ],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 288,
+                        "y": 496
+                    }
+                ]
+            },
+            {
+                "name": "Route 19",
+                "access_rules": [],
+                "sections": [],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 336,
+                        "y": 480
+                    }
+                ]
+            },
+            {
+                "name": "Route 18",
+                "access_rules": [
+                    "@Kanto/Route 18"
+                ],
+                "sections": [
+                    {
                         "name": "Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     },
-					{
-						"name": "Trade",
-						"access_rules": []
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 288, "y": 432 }]
-        },
-        {
-          "name": "Route 14",
-          "access_rules": ["$fuchsia"],
-          "sections": [
+                    {
+                        "name": "Trade",
+                        "access_rules": []
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 288,
+                        "y": 432
+                    }
+                ]
+            },
+            {
+                "name": "Route 14",
+                "access_rules": [
+                    "@Kanto/Route 14"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 6,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 432, "y": 400 }]
-        },
-        {
-          "name": "Route 12",
-          "access_rules": ["$vermilion","$lavender"],
-          "sections": [
-					{
-						"name": "Static Encounter: Snorlax",
-						"access_rules": ["pokeflute"],
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 432,
+                        "y": 400
+                    }
+                ]
+            },
+            {
+                "name": "Route 12",
+                "access_rules": [
+                    "^$vermilion",
+                    "^$lavender",
+					"^$fuchsia,^$extra_boulders",
+					"^$fuchsia,^$surf"
+                ],
+                "sections": [
+                    {
+                        "name": "Static Encounter: Snorlax",
+                        "access_rules": [
+                            "pokeflute"
+                        ],
                         "chest_unopened_img": "images/pokedex/snorlax.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
-					}
-          ],
-          "map_locations": [{ "map": "encounters", "x": 528, "y": 304 }]
-        },
-        {
-          "name": "Route 8",
-          "access_rules": ["$cut,$lavender"],
-          "sections": [
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 528,
+                        "y": 304
+                    }
+                ]
+            },
+            {
+                "name": "Route 8",
+                "access_rules": [
+                    "@Kanto/Route 8"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
                     },
                     {
                         "name": "Pokémon",
                         "item_count": 10,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_ten"
                         ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 464, "y": 176 }]
-        },
-        {
-          "name": "Route 7",
-          "access_rules": ["$celadon"],
-          "sections": [
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 464,
+                        "y": 176
+                    }
+                ]
+            },
+            {
+                "name": "Route 7",
+                "access_rules": [
+                    "^$celadon"
+                ],
+                "sections": [
                     {
                         "name": "Pokémon 1:1",
                         "item_count": 4,
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
-                    }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 352, "y": 176 }]
-        },
-        {
-          "name": "Route 6",
-          "access_rules": ["$cerulean"],
-          "sections": [
-                    {
-                        "name": "Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"]
-                    }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 400, "y": 240 }]
-        },
-        {
-          "name": "Route 3",
-          "access_rules": ["$pewter,$rt3","$cerulean,$surf"],
-          "sections": [
-                    {
-                        "name": "Pokémon 1:1",
-                        "item_count": 3,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one"]
-                    },
-                    {
-                        "name": "Pokémon",
-                        "item_count": 10,
-                        "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_ten"
+                        "visibility_rules": [
+                            "opt_encounter_one"
                         ]
                     },
-		  {
-			  "name": "Static Encounter: Buy Magikarp",
+                    {
+                        "name": "Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 352,
+                        "y": 176
+                    }
+                ]
+            },
+            {
+                "name": "Route 6",
+                "access_rules": [
+                    "@Kanto/Route 6"
+                ],
+                "sections": [
+                    {
+                        "name": "Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 400,
+                        "y": 240
+                    }
+                ]
+            },
+            {
+                "name": "Route 3",
+                "access_rules": [
+                    "@Kanto/Route 3"
+                ],
+                "sections": [
+                    {
+                        "name": "Pokémon 1:1",
+                        "item_count": 3,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_one"
+                        ]
+                    },
+                    {
+                        "name": "Pokémon",
+                        "item_count": 10,
+                        "clear_as_group": false,
+                        "visibility_rules": [
+                            "opt_encounter_ten"
+                        ]
+                    },
+                    {
+                        "name": "Static Encounter: Buy Magikarp",
                         "chest_unopened_img": "images/pokedex/magikarp.png"
-		  }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 208, "y": 112 }]
-        },
-        {
-          "name": "Indigo Plateau",
-          "access_rules": ["$indigo,$elite4"],
-          "sections": [
-
-          ],
-          "map_locations": [{ "map": "encounters", "x": 80, "y": 80, "size": 27, "border_thickness": 4 }]
-        },
-        {
-          "name": "Celadon Game Corner",
-          "access_rules": ["$celadon,coincase"],
-          "chest_unopened_img": "images/items/coincase.png",
-          "chest_opened_img": "images/items/coincase_done.png",
-          "sections": [
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 208,
+                        "y": 112
+                    }
+                ]
+            },
+            {
+                "name": "Celadon Game Corner",
+                "access_rules": [
+                    "^$celadon,coincase"
+                ],
+                "chest_unopened_img": "images/items/coincase.png",
+                "chest_opened_img": "images/items/coincase_done.png",
+                "sections": [
                     {
                         "name": "Prize Corner Left - 1",
                         "item_count": 1,
                         "clear_as_group": false,
-                        "visibility_rules": [""]
+                        "visibility_rules": [
+                            ""
+                        ]
                     },
                     {
                         "name": "Prize Corner Left - 2",
                         "item_count": 1,
                         "clear_as_group": false,
-                        "visibility_rules": [""]
+                        "visibility_rules": [
+                            ""
+                        ]
                     },
                     {
                         "name": "Prize Corner Left - 3",
                         "item_count": 1,
                         "clear_as_group": false,
-                        "visibility_rules": [""]
+                        "visibility_rules": [
+                            ""
+                        ]
                     },
                     {
                         "name": "Prize Corner Middle - 1",
                         "item_count": 1,
                         "clear_as_group": false,
-                        "visibility_rules": [""]
+                        "visibility_rules": [
+                            ""
+                        ]
                     },
                     {
                         "name": "Prize Corner Middle - 2",
                         "item_count": 1,
                         "clear_as_group": false,
-                        "visibility_rules": [""]
+                        "visibility_rules": [
+                            ""
+                        ]
                     },
                     {
                         "name": "Prize Corner Middle - 3",
                         "item_count": 1,
                         "clear_as_group": false,
-                        "visibility_rules": [""]
+                        "visibility_rules": [
+                            ""
+                        ]
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "x": 320, "y": 208 }]
-        },
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 320,
+                        "y": 208
+                    }
+                ]
+            },
             {
                 "name": "Fishing Is Fun",
                 "access_rules": [
@@ -1329,7 +1986,10 @@
                     {
                         "name": "Old Rod (Any Spot)",
                         "item_count": 1,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "chest_unopened_img": "images/items/oldrod.png",
                         "chest_opened_img": "images/items/oldrod_done.png",
                         "clear_as_group": false,
@@ -1343,7 +2003,10 @@
                         "chest_unopened_img": "images/items/goodrod.png",
                         "chest_opened_img": "images/items/goodrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
                             "goodrod"
                         ]
@@ -1354,7 +2017,10 @@
                         "chest_unopened_img": "images/items/goodrod.png",
                         "chest_opened_img": "images/items/goodrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
                             "superrod"
                         ]
@@ -1365,7 +2031,10 @@
                         "chest_unopened_img": "images/items/goodrod.png",
                         "chest_opened_img": "images/items/goodrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
                             "superrod"
                         ]
@@ -1376,9 +2045,12 @@
                         "chest_unopened_img": "images/items/superrod.png",
                         "chest_opened_img": "images/items/superrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "superrod,$cerulean"
+                            "superrod,^$cerulean"
                         ]
                     },
                     {
@@ -1387,9 +2059,12 @@
                         "chest_unopened_img": "images/items/superrod.png",
                         "chest_opened_img": "images/items/superrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "superrod,$cerulean"
+                            "superrod,^$cerulean"
                         ]
                     },
                     {
@@ -1398,9 +2073,12 @@
                         "chest_unopened_img": "images/items/superrod.png",
                         "chest_opened_img": "images/items/superrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "superrod,$celadon"
+                            "superrod,^$celadon"
                         ]
                     },
                     {
@@ -1409,9 +2087,12 @@
                         "chest_unopened_img": "images/items/superrod.png",
                         "chest_opened_img": "images/items/superrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "superrod,safaripass,$fuchsia"
+                            "superrod,safaripass,^$fuchsia"
                         ]
                     },
                     {
@@ -1420,12 +2101,15 @@
                         "chest_unopened_img": "images/items/superrod.png",
                         "chest_opened_img": "images/items/superrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "superrod,$lavender",
-                            "superrod,$fuchsia",
-                            "superrod,$celadon,pokeflute,$cyclingroad",
-                            "superrod,$fuchsia,$cyclingroad"
+                            "superrod,^$lavender",
+                            "superrod,^$fuchsia",
+                            "superrod,^$celadon,pokeflute,^$cyclingroad",
+                            "superrod,^$fuchsia,^$cyclingroad"
                         ]
                     },
                     {
@@ -1434,9 +2118,12 @@
                         "chest_unopened_img": "images/items/superrod.png",
                         "chest_opened_img": "images/items/superrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "superrod,$cinnabar"
+                            "superrod,^$cinnabar"
                         ]
                     },
                     {
@@ -1445,10 +2132,13 @@
                         "chest_unopened_img": "images/items/superrod.png",
                         "chest_opened_img": "images/items/superrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "superrod,$rt23",
-                            "superrod,$ceruleancave,$cerulean,$surf"
+                            "superrod,^$rt23",
+                            "superrod,^$ceruleancave,^$cerulean,$surf"
                         ]
                     },
                     {
@@ -1457,9 +2147,12 @@
                         "chest_unopened_img": "images/items/superrod.png",
                         "chest_opened_img": "images/items/superrod_done.png",
                         "clear_as_group": false,
-                        "visibility_rules": ["opt_encounter_one","opt_encounter_ten"],
+                        "visibility_rules": [
+                            "opt_encounter_one",
+                            "opt_encounter_ten"
+                        ],
                         "access_rules": [
-                            "superrod,$fuchsia"
+                            "superrod,^$fuchsia"
                         ]
                     }
                 ],
@@ -1471,35 +2164,43 @@
                     }
                 ]
             },
-        {
-          "name": "READ ME",
-          "access_rules": [],
-          "sections": [
-					{
-			            "access_rules": ["{$scoutable}"],
-						"name": "",
-						"chest_unopened_img": "images/items/doesnotexist.png",
-						"chest_opened_img": "images/items/doesnotexist.png"
-					},
+            {
+                "name": "READ ME",
+                "access_rules": [],
+                "sections": [
+                    {
+                        "access_rules": [
+                            "{$scoutable}"
+                        ],
+                        "name": "",
+                        "chest_unopened_img": "images/items/doesnotexist.png",
+                        "chest_opened_img": "images/items/doesnotexist.png"
+                    },
                     {
                         "name": "This map can only be operated manually.\nYou can backup your current state and then\nload it up again if you're using this map in an Async.",
                         "clear_as_group": false,
                         "visibility_rules": [],
-						"access_rules": [],
-						"hosted_item": "opt_encounter"
+                        "access_rules": [],
+                        "hosted_item": "opt_encounter"
                     },
                     {
                         "name": "With the above setting you can trigger whether you got\n1:1 mapping (original number of PKMN per place) or\nFull mapping (10 PKMN per place)",
                         "clear_as_group": false,
                         "visibility_rules": [],
-						"access_rules": [],
-						"chest_unopened_img": "images/items/doesnotexist.png",
-						"chest_opened_img": "images/items/doesnotexist.png"
+                        "access_rules": [],
+                        "chest_unopened_img": "images/items/doesnotexist.png",
+                        "chest_opened_img": "images/items/doesnotexist.png"
                     }
-          ],
-          "map_locations": [{ "map": "encounters", "size": 20, "x": 608, "y": 507 }]
-        }
-      ]
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "size": 20,
+                        "x": 608,
+                        "y": 507
+                    }
+                ]
+            }
+        ]
     }
-  ]
-  
+]

--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -158,7 +158,7 @@
                 ]
             },
             {
-                "name": "Route 2",
+                "name": "Route 2", ## Route 2 in locations.json has $cut as a requirement since all items are cut-locked. So, here we use custom access rules.
                 "access_rules": [
                     "^$pewter",
                     "$cut",
@@ -185,7 +185,7 @@
                         "name": "Trade",
                         "access_rules": [
                             "$cut",
-                            "^$vermilion"
+                            "@Kanto/Vermilion City" # Trade is possible without cut if you come from Vermillion
                         ]
                     }
                 ],
@@ -201,7 +201,7 @@
                 "name": "Diglett's Cave",
                 "access_rules": [
                     "$cut",
-                    "^$vermilion"
+                    "@Kanto/Vermilion City"
                 ],
                 "sections": [
                     {
@@ -331,7 +331,7 @@
             {
                 "name": "Lavender Town",
                 "access_rules": [
-                    "$lavender"
+                    "@Kanto/Lavender Town"
                 ],
                 "sections": [],
                 "map_locations": [
@@ -361,7 +361,7 @@
             {
                 "name": "Route 11-12 Gatehouse",
                 "access_rules": [
-                    "^$vermilion,^$extra_boulders","^$lavender,pokeflute"
+                    "@Kanto/Route 11-12 Gatehouse"
                 ],
                 "sections": [
                     {
@@ -380,7 +380,7 @@
             {
                 "name": "Silph Co 1F - 6F",
                 "access_rules": [
-                    "$saffron,fuji"
+                    "@Kanto/Saffron City, fuji"
                 ],
                 "sections": [],
                 "map_locations": [
@@ -441,8 +441,7 @@
                     {
                         "name": "Static Encounter: Snorlax",
                         "access_rules": [
-                            "pokeflute,^$celadon",
-                            "pokeflute,^$fuchsia,^$cyclingroad"
+                            "pokeflute, @Kanto/Celadon City" // If you have the pokeflute and come from below, you already have access to celadon
                         ],
                         "chest_unopened_img": "images/pokedex/snorlax.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
@@ -640,7 +639,7 @@
             {
                 "name": "Route 4",
                 "access_rules": [
-                    "^$cerulean"
+                    "@Kanto/Cerulean City" # Route 4 has more requirements in locations.json. Route 4-Mons can be accessed if you have access to cerulean.
                 ],
                 "sections": [
                     {
@@ -1761,17 +1760,12 @@
             {
                 "name": "Route 12",
                 "access_rules": [
-                    "^$vermilion",
-                    "^$lavender",
-					"^$fuchsia,^$extra_boulders",
-					"^$fuchsia,^$surf"
+                    "@Kanto/Lavender Town, pokeflute" # If you have access to Snorlax from the west or south and have a flute, you also have access to lavender
                 ],
                 "sections": [
                     {
                         "name": "Static Encounter: Snorlax",
-                        "access_rules": [
-                            "pokeflute"
-                        ],
+                        "access_rules": [],
                         "chest_unopened_img": "images/pokedex/snorlax.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
                     }
@@ -1818,7 +1812,7 @@
             {
                 "name": "Route 7",
                 "access_rules": [
-                    "^$celadon"
+                    "@Kanto/Celadon City"
                 ],
                 "sections": [
                     {
@@ -1915,7 +1909,7 @@
             {
                 "name": "Celadon Game Corner",
                 "access_rules": [
-                    "^$celadon,coincase"
+                    "@Kanto/Celadon City,coincase"
                 ],
                 "chest_unopened_img": "images/items/coincase.png",
                 "chest_opened_img": "images/items/coincase_done.png",

--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -51,7 +51,7 @@
                         "name": "Pokémon 1:1",
                         "item_count": 3,
                         "access_rules": [
-                            "$cut"
+                            "^$cut"
                         ],
                         "clear_as_group": false,
                         "visibility_rules": [
@@ -62,7 +62,7 @@
                         "name": "Pokémon",
                         "item_count": 10,
                         "access_rules": [
-                            "$cut"
+                            "^$cut"
                         ],
                         "clear_as_group": false,
                         "visibility_rules": [
@@ -160,9 +160,9 @@
             {
                 "name": "Route 2", // Route 2 in locations.json has $cut as a requirement since all items are cut-locked. So, here we use custom access rules.
                 "access_rules": [
-                    "^$pewter",
-                    "$cut",
-                    "$old_man"
+                    "@Kanto/Pewter City",
+                    "^$cut",
+                    "^$old_man"
                 ],
                 "sections": [
                     {
@@ -184,7 +184,7 @@
                     {
                         "name": "Trade",
                         "access_rules": [
-                            "$cut",
+                            "^$cut",
                             "@Kanto/Vermilion City" // Trade is possible without cut if you come from Vermillion
                         ]
                     }
@@ -200,7 +200,7 @@
             {
                 "name": "Diglett's Cave",
                 "access_rules": [
-                    "$cut",
+                    "^$cut",
                     "@Kanto/Vermilion City"
                 ],
                 "sections": [
@@ -1026,7 +1026,7 @@
                         "item_count": 8,
                         "clear_as_group": false,
                 "access_rules": [
-                    "^$rt23, ^$victoryroad, $surf", "^$indigo, $strength"
+                    "^$rt23, ^$victoryroad, ^$surf", "@Kanto/Indigo Plateau, ^$strength"
                 ],
                         "visibility_rules": [
                             "dexsanity_one"
@@ -1037,7 +1037,7 @@
                         "item_count": 10,
                         "clear_as_group": false,
                 "access_rules": [
-                    "^$rt23, ^$victoryroad, $surf", "^$indigo, $strength"
+                    "^$rt23, ^$victoryroad, ^$surf", "@Kanto/Indigo Plateau, ^$strength"
                 ],
                         "visibility_rules": [
                             "opt_encounter_ten"
@@ -1048,7 +1048,7 @@
                         "item_count": 9,
                         "clear_as_group": false,
                 "access_rules": [
-                    "^$indigo" // This is specifically because you can reach a small 3x3 section of 2F by going backwards, with no strength. If you go forwards you have indigo access either way.
+                    "@Kanto/Indigo Plateau" // This is specifically because you can reach a small 3x3 section of 2F by going backwards, with no strength. If you go forwards you have indigo access either way.
                 ],
                         "visibility_rules": [
                             "opt_encounter_one"
@@ -1059,7 +1059,7 @@
                         "item_count": 10,
                         "clear_as_group": false,
                 "access_rules": [
-                    "^$indigo" // This is specifically because you can reach a small 3x3 section of 2F by going backwards, with no strength. If you go forwards you have indigo access either way.
+                    "@Kanto/Indigo Plateau" // This is specifically because you can reach a small 3x3 section of 2F by going backwards, with no strength. If you go forwards you have indigo access either way.
                 ],
                         "visibility_rules": [
                             "opt_encounter_ten"
@@ -1070,7 +1070,7 @@
                         "item_count": 8,
                         "clear_as_group": false,
                 "access_rules": [
-                    "^$indigo"
+                    "@Kanto/Indigo Plateau"
                 ],
                         "visibility_rules": [
                             "opt_encounter_one"
@@ -1081,7 +1081,7 @@
                         "item_count": 10,
                         "clear_as_group": false,
                 "access_rules": [
-                    "^$indigo"
+                    "@Kanto/Indigo Plateau"
                 ],
                         "visibility_rules": [
                             "opt_encounter_ten"
@@ -1089,7 +1089,7 @@
                     },
                     {
                         "name": "Static Encounter: Moltres",
-                        "access_rules": ["^$indigo, $strength"],
+                        "access_rules": ["@Kanto/Indigo Plateau, ^$strength"],
                         "chest_unopened_img": "images/pokedex/moltres.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
                     }
@@ -1312,7 +1312,7 @@
                         "name": "Pokémon 1:1",
                         "item_count": 5,
                         "access_rules": [
-                            "$cut"
+                            "^$cut"
                         ],
                         "clear_as_group": false,
                         "visibility_rules": [
@@ -1323,7 +1323,7 @@
                         "name": "Pokémon",
                         "item_count": 10,
                         "access_rules": [
-                            "$cut"
+                            "^$cut"
                         ],
                         "clear_as_group": false,
                         "visibility_rules": [
@@ -1428,7 +1428,7 @@
                     {
                         "name": "Static Encounter: Articuno",
                         "access_rules": [
-                            "$strength"
+                            "^$strength"
                         ],
                         "chest_unopened_img": "images/pokedex/articuno.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
@@ -1544,7 +1544,7 @@
                     {
                         "name": "Static Encounter: Mew",
                         "access_rules": [
-                            "$surf"
+                            "^$surf"
                         ],
                         "chest_unopened_img": "images/pokedex/mew.png",
                         "chest_opened_img": "images/items/pokedex_done.png"
@@ -1681,7 +1681,7 @@
             },
             {
                 "name": "Route 19",
-                "access_rules": [],
+                "access_rules": ["@Kanto/Fuchsia City"],
                 "sections": [],
                 "map_locations": [
                     {
@@ -2044,7 +2044,7 @@
                             "opt_encounter_ten"
                         ],
                         "access_rules": [
-                            "superrod,^$cerulean"
+                            "superrod,@Kanto/Cerulean City"
                         ]
                     },
                     {
@@ -2058,7 +2058,7 @@
                             "opt_encounter_ten"
                         ],
                         "access_rules": [
-                            "superrod,^$cerulean"
+                            "superrod,@Kanto/Vermilion City"
                         ]
                     },
                     {
@@ -2072,7 +2072,7 @@
                             "opt_encounter_ten"
                         ],
                         "access_rules": [
-                            "superrod,^$celadon"
+                            "superrod,@Kanto/Celadon City"
                         ]
                     },
                     {
@@ -2086,7 +2086,7 @@
                             "opt_encounter_ten"
                         ],
                         "access_rules": [
-                            "superrod,safaripass,^$fuchsia"
+                            "superrod,@Kanto/Safari Zone"
                         ]
                     },
                     {
@@ -2100,10 +2100,8 @@
                             "opt_encounter_ten"
                         ],
                         "access_rules": [
-                            "superrod,^$lavender",
-                            "superrod,^$fuchsia",
-                            "superrod,^$celadon,pokeflute,^$cyclingroad",
-                            "superrod,^$fuchsia,^$cyclingroad"
+                            "superrod,@Kanto/Lavender Town", //rt 12 north can be accessed from Lavender and has the same rules
+                            "superrod,@Kanto/Fuchsia City", //12 South, 13, 17 and 18 can all be accessed from Fuchsia. Bicycle Road doesn't matter because if you can get there you can get to 17
                         ]
                     },
                     {
@@ -2117,7 +2115,7 @@
                             "opt_encounter_ten"
                         ],
                         "access_rules": [
-                            "superrod,^$cinnabar"
+                            "superrod,@Kanto/Cinnabar Island"
                         ]
                     },
                     {
@@ -2131,8 +2129,8 @@
                             "opt_encounter_ten"
                         ],
                         "access_rules": [
-                            "superrod,^$rt23",
-                            "superrod,^$ceruleancave,^$cerulean,$surf"
+                            "superrod,^$rt23", //@ Rules don't work because all 
+                            "superrod,@Kanto/Cerulean Cave"
                         ]
                     },
                     {
@@ -2146,7 +2144,7 @@
                             "opt_encounter_ten"
                         ],
                         "access_rules": [
-                            "superrod,^$fuchsia"
+                            "superrod,@Kanto/Fuchsia City"
                         ]
                     }
                 ],


### PR DESCRIPTION
I hope this isn't "Kitchen Sink". I'm still not sure what the term means, I tried to google it. But I think it should be fine since it's all one file and one aim?

This:
- converts all access rules to @Kanto/Location rules if possible
- compared to my last PR-attempt, I did just @Kanto/Location instead of a specific route as you suggested. It worked.
- adds ^ to all location rules (the only time it's not used is for HM-functions)
- more granulated behavior with Victory Road as access can be on some floors but not others
- Fix that all Pokémon in Pokémon Tower need Silph Scope