### PR TITLE
Add missing cut requirement to Route 14 encounters

### DIFF
--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -1729,7 +1729,7 @@
             {
                 "name": "Route 14",
                 "access_rules": [
-                    "@Kanto/Route 14"
+                    "@Kanto/Route 14, ^$cut"
                 ],
                 "sections": [
                     {


### PR DESCRIPTION
The only grass patch on rt14 is locked behind a cuttable bush.