### PR TITLE
Fixed incorrect visiblity rule

### DIFF
--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -1029,7 +1029,7 @@
                     "^$rt23, ^$victoryroad, ^$surf", "@Kanto/Indigo Plateau, ^$strength"
                 ],
                         "visibility_rules": [
-                            "dexsanity_one"
+                            "opt_encounter_one"
                         ]
                     },
                     {


### PR DESCRIPTION
VR 1F had `dexsanity_one` instead of `opt_encounter_one`