### PR TITLE
0.5.1 keyitem logic

### DIFF
--- a/items/items.json
+++ b/items/items.json
@@ -358,7 +358,7 @@
         "name": "Oak's Parcel",
         "type": "toggle",
         "img": "images/items/oaksparcel.png",
-        "codes": "parcel"
+        "codes": "parcel,newkeyitem"
     },
     {
         "name": "Pokedex",
@@ -431,7 +431,7 @@
         "name": "Gold Teeth",
         "type": "toggle",
         "img": "images/items/goldteeth.png",
-        "codes": "goldteeth,teeth"
+        "codes": "goldteeth,teeth,newkeyitem"
     },
     {
         "name": "Secret Key",
@@ -443,7 +443,7 @@
         "name": "Bike Voucher",
         "type": "toggle",
         "img": "images/items/bikevoucher.png",
-        "codes": "voucher"
+        "codes": "voucher,newkeyitem"
     },
     {
         "name": "Lift Key",
@@ -626,7 +626,7 @@
             },
             {
                 "name": "Tea",
-                "codes": "tea",
+                "codes": "tea, newkeyitem",
                 "img": "images/items/tea.png"
             }
         ]
@@ -743,19 +743,19 @@
         "name": "Old Amber",
         "type": "toggle",
         "img": "images/items/oldamber.png",
-        "codes": "oldamber,fossil"
+        "codes": "oldamber,fossil,newkeyitem"
     },
     {
         "name": "Dome Fossil",
         "type": "toggle",
         "img": "images/items/dome.png",
-        "codes": "domefossil,fossil"
+        "codes": "domefossil,fossil,newkeyitem"
     },
     {
         "name": "Helix Fossil",
         "type": "toggle",
         "img": "images/items/helix.png",
-        "codes": "helixfossil,fossil"
+        "codes": "helixfossil,fossil,newkeyitem"
     },
     {
         "name": "Fire Stone",

--- a/items/options.json
+++ b/items/options.json
@@ -1,5 +1,25 @@
 [
     {
+        "name": "Secret 0.5.1 setting",
+        "type": "progressive",
+        "loop": false,
+        "allow_disabled": false,
+        "codes": "v5_update",
+        "stages": [
+            {
+                "name": "This is a 0.5.0 game",
+                "codes": "v5_update_false",
+                "img": "images/items/doesnotexist.png"
+            },
+            {
+                "name": "This is a 0.5.1 game",
+                "img": "images/items/doesnotexist.png",
+                "codes": "v5_update_true",
+                "inherit_codes": false
+            }
+        ]
+    },
+    {
         "name": "Bicycle Skip Patched",
         "type": "progressive",
         "loop": true,

--- a/layouts/itemgrid.json
+++ b/layouts/itemgrid.json
@@ -72,7 +72,8 @@
                                 "plantkey",
                                 "mansionkey",
                                 "hideoutkey",
-                                "safaripass"
+                                "safaripass",
+                                "v5_update"
                             ]
                         ]
                     }

--- a/scripts/autotracking/slot_options.lua
+++ b/scripts/autotracking/slot_options.lua
@@ -1,5 +1,11 @@
 function get_slot_options(slot_data)
 
+    if slot_data["v5_update"] ~= nil then
+		Tracker:FindObjectForCode('v5_update').CurrentStage = 1
+    else
+        Tracker:FindObjectForCode('v5_update').CurrentStage = 0
+	end    
+    
     if slot_data["second_fossil_check_condition"] then
 		Tracker:FindObjectForCode('opt_fossilcheck').AcquiredCount = slot_data["second_fossil_check_condition"]
 	end

--- a/scripts/autotracking/slot_options.lua
+++ b/scripts/autotracking/slot_options.lua
@@ -4,7 +4,7 @@ function get_slot_options(slot_data)
 		Tracker:FindObjectForCode('v5_update').CurrentStage = 1
     else
         Tracker:FindObjectForCode('v5_update').CurrentStage = 0
-	end    
+    end    
     
     if slot_data["second_fossil_check_condition"] then
 		Tracker:FindObjectForCode('opt_fossilcheck').AcquiredCount = slot_data["second_fossil_check_condition"]

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -36,8 +36,11 @@ function badges_count()
 end
 -- returns int of # of key items
 function key_items_count()
-    local count = 0
-    return count  + Tracker:ProviderCountForCode('keyitem')
+    if Tracker:FindObjectForCode('v5_update').CurrentStage == 0 then
+        return Tracker:ProviderCountForCode('keyitem')
+    elseif Tracker:FindObjectForCode('v5_update').CurrentStage == 1 then
+        return Tracker:ProviderCountForCode('keyitem') + Tracker:ProviderCountForCode('newkeyitem')
+    end
 end
 -- returns int of # of pokemon caught
 function pokedex_count()


### PR DESCRIPTION
Adds compatibility with 0.5.1 Key Item changes.
The following items will work as Key Items for the sake of E4 & CC if 0.5.1 is auto detected by slot data or if the player toggles the invisible toggle in the bottom right corner of the item grid:

"Oak's Parcel", "Helix Fossil", "Dome Fossil","Old Amber", "Tea", "Gold Teeth", "Bike Voucher"