### PR TITLE
Trainersanity fixes for next release of AP

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1608,15 +1608,15 @@
               "visibility_rules": ["$trainer_visible|172000529"]	
             },	
             {	
-              "name": "Gym: Super Nerd 4",	
-              "chest_unopened_img": "images/trainers/supernerd.png",
-              "chest_opened_img": "images/trainers/supernerd_done.png",
+              "name": "Gym: Burglar 2",	
+              "chest_unopened_img": "images/trainers/burglar.png",
+              "chest_opened_img": "images/trainers/burglar_done.png",
               "item_count": 1,	
               "access_rules": ["secretkey"],	
               "visibility_rules": ["$trainer_visible|172000530"]	
             },	
             {	
-              "name": "Gym: Super Nerd 5",	
+              "name": "Gym: Super Nerd 4",	
               "chest_unopened_img": "images/trainers/supernerd.png",
               "chest_opened_img": "images/trainers/supernerd_done.png",
               "item_count": 1,	


### PR DESCRIPTION
Adjusts trainersanity location names to match changes to the Archipelago locations

Relabels Super Nerd 4 to be Burglar 3 and Super Nerd 5 as Super Nerd 4